### PR TITLE
.readExternal support for objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,8 @@ module.exports = function (order) {
     };
 
     self.readExternal = function(data) {
-        db = JSON.parse(data);
+        if (typeof data == 'object') db = data;
+        else db = JSON.parse(data);
     };
 
     self.writeExternal = function() {


### PR DESCRIPTION
before .readExternal would throw an error if you fed it an object. This change allows .readExternal to be fed either an object or a string